### PR TITLE
Do not use `import2()` more for webpack build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "samchon.github@gmail.com",
     "url": "https://github.com/samchon"
   },
-  "version": "0.8.8",
+  "version": "0.8.9",
   "main": "index.js",
   "typings": "index.d.ts",
   "scripts": {
@@ -26,7 +26,6 @@
     "test:node": "node dist/test/node"
   },
   "dependencies": {
-    "import2": "^1.0.0",
     "serialize-error": "^4.1.0",
     "tstl": "^2.5.13",
     "uuid": "^9.0.0",

--- a/src/utils/internal/NodeModule.ts
+++ b/src/utils/internal/NodeModule.ts
@@ -1,4 +1,3 @@
-import include from "import2";
 import type * as __cp from "child_process";
 import type * as __fs from "fs";
 import type * as __http from "http";
@@ -11,24 +10,24 @@ import { Singleton } from "tstl/thread/Singleton";
 
 export namespace NodeModule {
     export const cp: Singleton<Promise<typeof __cp>> = new Singleton(() =>
-        include("child_process"),
+        import("child_process"),
     );
     export const fs: Singleton<Promise<typeof __fs>> = new Singleton(() =>
-        include("fs"),
+        import("fs"),
     );
     export const http: Singleton<Promise<typeof __http>> = new Singleton(() =>
-        include("http"),
+        import("http"),
     );
     export const https: Singleton<Promise<typeof __https>> = new Singleton(() =>
-        include("https"),
+        import("https"),
     );
     export const os: Singleton<Promise<typeof __os>> = new Singleton(() =>
-        include("os"),
+        import("os"),
     );
     export const thread: Singleton<Promise<typeof __thread>> = new Singleton(
-        () => include("worker_threads"),
+        () => import("worker_threads"),
     );
     export const ws: Singleton<Promise<typeof __ws>> = new Singleton(() =>
-        include("ws"),
+        import("ws"),
     );
 }


### PR DESCRIPTION
When building webpack of node application without node_modules, `import2()` statements be a great obstable for that.
