### PR TITLE
Use `import2` for NodeJS built-in modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tgrid",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "description": "Grid Computing Framework for TypeScript",
@@ -22,6 +22,7 @@
     "test:node": "node bin/test/node"
   },
   "dependencies": {
+    "import2": "^1.0.3",
     "serialize-error": "^4.1.0",
     "tstl": "^2.5.13",
     "uuid": "^9.0.1",

--- a/src/protocols/workers/internal/WebWorkerCompiler.ts
+++ b/src/protocols/workers/internal/WebWorkerCompiler.ts
@@ -8,12 +8,12 @@ export const WebWorkerCompiler = async (): Promise<IWorkerCompiler> => ({
     const blob: Blob = new Blob([content], {
       type: "application/javascript",
     });
-    return window.URL.createObjectURL(blob);
+    return self.URL.createObjectURL(blob);
   },
   remove: async (url) => {
     // THE FILE CAN BE REMOVED BY BROWSER AUTOMATICALLY
     try {
-      window.URL.revokeObjectURL(url);
+      self.URL.revokeObjectURL(url);
     } catch {}
   },
   execute: async (jsFile) => new Worker(jsFile),

--- a/src/utils/internal/NodeModule.ts
+++ b/src/utils/internal/NodeModule.ts
@@ -6,26 +6,27 @@ import type * as __os from "os";
 import type * as __thread from "worker_threads";
 import type * as __ws from "ws";
 
+import import2 from "import2";
 import { Singleton } from "tstl/thread/Singleton";
 
 export namespace NodeModule {
-  export const cp: Singleton<Promise<typeof __cp>> = new Singleton(
-    () => import("child_process"),
+  export const cp: Singleton<Promise<typeof __cp>> = new Singleton(() =>
+    import2("child_process"),
   );
-  export const fs: Singleton<Promise<typeof __fs>> = new Singleton(
-    () => import("fs"),
+  export const fs: Singleton<Promise<typeof __fs>> = new Singleton(() =>
+    import2("fs"),
   );
-  export const http: Singleton<Promise<typeof __http>> = new Singleton(
-    () => import("http"),
+  export const http: Singleton<Promise<typeof __http>> = new Singleton(() =>
+    import2("http"),
   );
-  export const https: Singleton<Promise<typeof __https>> = new Singleton(
-    () => import("https"),
+  export const https: Singleton<Promise<typeof __https>> = new Singleton(() =>
+    import2("https"),
   );
-  export const os: Singleton<Promise<typeof __os>> = new Singleton(
-    () => import("os"),
+  export const os: Singleton<Promise<typeof __os>> = new Singleton(() =>
+    import2("os"),
   );
-  export const thread: Singleton<Promise<typeof __thread>> = new Singleton(
-    () => import("worker_threads"),
+  export const thread: Singleton<Promise<typeof __thread>> = new Singleton(() =>
+    import2("worker_threads"),
   );
   export const ws: Singleton<Promise<typeof __ws>> = new Singleton(
     () => import("ws"),

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -5,7 +5,10 @@
     "paths": {
       "tgrid": ["../src"],
       "tgrid/lib/*": ["../src/*"],
-    }
+    },
+    "plugins": [
+      { "transform": "typescript-transform-paths" },
+    ],
   },
   "include": [
     "./", 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,9 +58,6 @@
     "skipLibCheck": true,
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
-    "plugins": [
-      { "transform": "typescript-transform-paths" },
-    ],
   },
   "include": ["src"]
 }


### PR DESCRIPTION
For webpack and rollup bundling of the web-browser mode.