### PR TITLE
Compatible with https://esm.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tgrid",
-  "version": "0.9.3",
+  "version": "0.9.7",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "description": "Grid Computing Framework for TypeScript",
@@ -24,8 +24,7 @@
   "dependencies": {
     "import2": "^1.0.3",
     "serialize-error": "^4.1.0",
-    "tstl": "^2.5.13",
-    "uuid": "^9.0.1",
+    "tstl": "^2.5.16",
     "ws": "^7.5.3"
   },
   "devDependencies": {
@@ -33,7 +32,6 @@
     "@types/browserify": "^12.0.40",
     "@types/node": "^20.11.26",
     "@types/puppeteer": "^7.0.4",
-    "@types/uuid": "^9.0.8",
     "@types/ws": "^7.4.7",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",

--- a/src/protocols/workers/internal/NodeWorkerCompiler.ts
+++ b/src/protocols/workers/internal/NodeWorkerCompiler.ts
@@ -1,4 +1,3 @@
-import { v4 } from "uuid";
 import { NodeModule } from "../../../utils/internal/NodeModule";
 
 import { FileSystem } from "./FileSystem";
@@ -23,7 +22,7 @@ export const NodeWorkerCompiler = async (
     if ((await FileSystem.exists(path)) === false) await FileSystem.mkdir(path);
 
     while (true) {
-      const myPath: string = `${path}/${v4()}.js`;
+      const myPath: string = `${path}/${uuid()}.js`;
       if ((await FileSystem.exists(myPath)) === false) {
         path = myPath;
         break;
@@ -43,3 +42,10 @@ export const NodeWorkerCompiler = async (
   //     return new this.factory_(jsFile, execArgv) as any;
   // }
 });
+
+const uuid = () =>
+  "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });

--- a/src/protocols/workers/internal/processes/ProcessChannel.ts
+++ b/src/protocols/workers/internal/processes/ProcessChannel.ts
@@ -1,22 +1,24 @@
+import { NodeModule } from "../../../../utils/internal/NodeModule";
+
 /**
  * @hidden
  */
 export class ProcessChannel {
   public static postMessage(message: any): void {
-    (global.process as Required<NodeJS.Process>).send(message);
+    NodeModule.process().send!(message);
   }
 
   public static close(): void {
-    global.process.exit();
+    NodeModule.process().exit();
   }
 
   public static set onmessage(listener: (event: MessageEvent) => void) {
-    global.process.on("message", (msg) => {
+    NodeModule.process().on("message", (msg) => {
       listener({ data: msg } as MessageEvent);
     });
   }
 
   public static is_worker_server(): boolean {
-    return !!global.process.send;
+    return !!NodeModule.process().send;
   }
 }

--- a/src/protocols/workers/internal/threads/ThreadPort.ts
+++ b/src/protocols/workers/internal/threads/ThreadPort.ts
@@ -8,9 +8,10 @@ import { NodeModule } from "../../../../utils/internal/NodeModule";
  */
 export async function ThreadPort() {
   const { parentPort } = await NodeModule.thread.get();
+  const process = NodeModule.process();
   return {
     postMessage: (message: any) => parentPort!.postMessage(message),
-    close: () => global.process.exit(0),
+    close: () => process.exit(0),
     onmessage: (listener: (event: MessageEvent) => void) =>
       parentPort!.on("message", (message) =>
         listener({ data: message } as MessageEvent),

--- a/src/utils/internal/NodeModule.ts
+++ b/src/utils/internal/NodeModule.ts
@@ -5,6 +5,7 @@ import type * as __https from "https";
 import type * as __os from "os";
 import type * as __thread from "worker_threads";
 import type * as __ws from "ws";
+import type * as __process from "process";
 
 import import2 from "import2";
 import { Singleton } from "tstl/thread/Singleton";
@@ -31,4 +32,10 @@ export namespace NodeModule {
   export const ws: Singleton<Promise<typeof __ws>> = new Singleton(
     () => import("ws"),
   );
+  export const process = () => __global.process;
 }
+
+/**
+ * @internal
+ */
+const __global = global;


### PR DESCRIPTION
I'm making a cloud playground website that can import any library registered in the NPM registry with `esm.sh`.

By the way, as `esm.sh` has been published for `deno`, it is not possible to import `NodeJS` built-in libraries.

In such reason, this PR removes every direct import statements to the NodeJS built-in libraries, and performed indirect import through `import2` library, so that bundler cannot merge them.
