### PR TITLE
Refactor names of WebSockeet related classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ However, whatever [Grid Computing](#12-grid-computing) and *Remote Function Call
 
 #### [`composite-calculator/server.ts`](https://github.com/samchon/tgrid.examples/blob/master/src/projects/composite-calculator/server.ts)
 ```typescript
-import { WebServer } from "tgrid/protocols/web";
+import { WebSocketServer } from "tgrid/protocols/web";
 import { CompositeCalculator } from "../../providers/Calculator";
 
 async function main(): Promise<void>
 {
-    const server: WebServer<object, CompositeCalculator> = new WebServer();
+    const server: WebSocketServer<object, CompositeCalculator> = new WebSocketServer();
     await server.open(10102, async acceptor =>
     {
         await acceptor.accept(new CompositeCalculator());
@@ -65,7 +65,7 @@ main();
 
 #### [`composite-calculator/client.ts`](https://github.com/samchon/tgrid.examples/blob/master/src/projects/composite-calculator/client.ts)
 ```typescript
-import { WebConnector } from "tgrid/protocols/web/WebConnector";
+import { WebSocketConnector } from "tgrid/protocols/web/WebSocketConnector";
 import { Driver } from "tgrid/components/Driver";
 
 import { ICalculator } from "../../controllers/ICalculator";
@@ -75,7 +75,7 @@ async function main(): Promise<void>
     //----
     // CONNECTION
     //----
-    const connector: WebConnector<null, null> = new WebConnector(null, null);
+    const connector: WebSocketConnector<null, null> = new WebSocketConnector(null, null);
     await connector.connect("ws://127.0.0.1:10102");
 
     //----
@@ -166,7 +166,7 @@ Let's assume a situation; There's a distributed processing system build by tradi
 Thus, with **TGrid** and [Remote Function Call](#13-remote-function-call), you can adapt compilation and type checking on the network system. It helps you to develop a network system safely and conveniently. Let's close this chapter with an example of *Safey Implementation*.
 
 ```typescript
-import { WebConnector } from "tgrid/protocols/web/WebConnector"
+import { WebSocketConnector } from "tgrid/protocols/web/WebSocketConnector"
 import { Driver } from "tgrid/components/Driver";
 
 interface ICalculator
@@ -184,7 +184,7 @@ async function main(): Promise<void>
     //----
     // CONNECTION
     //----
-    const connector: WebConnector<null, null> = new WebConnector(null, null);
+    const connector: WebSocketConnector<null, null> = new WebSocketConnector(null, null);
     await connector.connect("ws://127.0.0.1:10101");
 
     //----

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tgrid",
-  "version": "1.0.0-dev.20240506",
+  "version": "1.0.0-dev.20240507",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tgrid",
-  "version": "0.11.0",
+  "version": "1.0.0-dev.20240506",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "exports": {

--- a/src/components/Communicator.ts
+++ b/src/components/Communicator.ts
@@ -14,7 +14,7 @@ import { Invoke } from "./Invoke";
  * The basic communicator.
  *
  * The `Communicator` is an abstract class taking full charge of network communication.
- * Protocolized communicators like {@link WebConnector} are realized by extending this
+ * Protocolized communicators like {@link WebSocketConnector} are realized by extending this
  * `Communicator` class.
  *
  * You want to make your own communicator using special protocol, extends this `Communicator`

--- a/src/protocols/internal/IHeaderWrapper.ts
+++ b/src/protocols/internal/IHeaderWrapper.ts
@@ -1,12 +1,12 @@
 /**
- * @hidden
+ * @internal
  */
 export interface IHeaderWrapper<Headers> {
   header: Headers;
 }
 
 /**
- * @hidden
+ * @internal
  */
 export namespace IHeaderWrapper {
   export function wrap<Header>(header: Header): IHeaderWrapper<Header> {

--- a/src/protocols/internal/once.ts
+++ b/src/protocols/internal/once.ts
@@ -1,5 +1,5 @@
 /**
- * @hidden
+ * @internal
  */
 export function once<Func>(handler: Func): Func {
   let called: boolean = false;

--- a/src/protocols/web/WebSocketError.ts
+++ b/src/protocols/web/WebSocketError.ts
@@ -1,12 +1,10 @@
-import { DomainError } from "tstl";
-
 /**
  * Web Socket Error.
  *
  * @reference https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
  * @author Jeongho Nam - https://github.com/samchon
  */
-export class WebError extends DomainError {
+export class WebSocketError extends Error {
   public readonly status: number;
 
   /**
@@ -17,6 +15,12 @@ export class WebError extends DomainError {
    */
   public constructor(status: number, message: string) {
     super(message);
+
+    // INHERITANCE POLYFILL
+    const proto = new.target.prototype;
+    if (Object.setPrototypeOf) Object.setPrototypeOf(this, proto);
+    else (this as any).__proto__ = proto;
+
     this.status = status;
   }
 }

--- a/src/protocols/web/index.ts
+++ b/src/protocols/web/index.ts
@@ -1,4 +1,21 @@
-export * from "./WebServer";
-export * from "./WebAcceptor";
-export * from "./WebConnector";
-export * from "./WebError";
+import { WebSocketAcceptor } from "./WebSocketAcceptor";
+import { WebSocketConnector } from "./WebSocketConnector";
+import { WebSocketError } from "./WebSocketError";
+import { WebSocketServer } from "./WebSocketServer";
+
+export {
+  WebSocketServer,
+  WebSocketAcceptor,
+  WebSocketConnector,
+  WebSocketError,
+};
+
+/**
+ * @internal
+ */
+export {
+  WebSocketAcceptor as WebAcceptor,
+  WebSocketConnector as WebConnector,
+  WebSocketError as WebError,
+  WebSocketServer as WebServer,
+};

--- a/src/protocols/web/internal/IWebSocketCommunicator.ts
+++ b/src/protocols/web/internal/IWebSocketCommunicator.ts
@@ -3,7 +3,7 @@
  *
  * @author Jeongho Nam - https://github.com/samchon
  */
-export interface IWebCommunicator {
+export interface IWebSocketCommunicator {
   /**
    * Close connection.
    *
@@ -14,7 +14,7 @@ export interface IWebCommunicator {
    * causes all incompleted RFCs to throw exceptions.
    *
    * If parametric *code* and *reason* are specified, it means the disconnection is
-   * abnormal and it would throw special exceptions (`WebError`) to the incompleted RFCs.
+   * abnormal and it would throw special exceptions (`WebSocketError`) to the incompleted RFCs.
    *
    * @param code Closing code.
    * @param reason Reason why.

--- a/src/protocols/web/internal/WebSocketPolyfill.ts
+++ b/src/protocols/web/internal/WebSocketPolyfill.ts
@@ -1,5 +1,8 @@
 import { NodeModule } from "../../../utils/internal/NodeModule";
 
+/**
+ * @internal
+ */
 export async function WebSocketPolyfill() {
   const modulo = await NodeModule.ws.get();
   return modulo.default;

--- a/src/protocols/workers/internal/FileSystem.ts
+++ b/src/protocols/workers/internal/FileSystem.ts
@@ -3,7 +3,7 @@ import type fs from "fs";
 import { NodeModule } from "../../../utils/internal/NodeModule";
 
 /**
- * @hidden
+ * @internal
  */
 export namespace FileSystem {
   /* ----------------------------------------------------------------

--- a/src/protocols/workers/internal/IReject.ts
+++ b/src/protocols/workers/internal/IReject.ts
@@ -1,5 +1,5 @@
 /**
- * @hidden
+ * @internal
  */
 export interface IReject {
   name: "reject";

--- a/src/protocols/workers/internal/IWorkerCompiler.ts
+++ b/src/protocols/workers/internal/IWorkerCompiler.ts
@@ -1,5 +1,5 @@
 /**
- * @hidden
+ * @internal
  */
 export interface IWorkerCompiler {
   compile(content: string): Promise<string>;
@@ -8,7 +8,7 @@ export interface IWorkerCompiler {
 }
 
 /**
- * @hidden
+ * @internal
  */
 export namespace IWorkerCompiler {
   export type Creator = {

--- a/src/protocols/workers/internal/NodeWorkerCompiler.ts
+++ b/src/protocols/workers/internal/NodeWorkerCompiler.ts
@@ -5,7 +5,7 @@ import { ProcessWorker } from "./processes/ProcessWorker";
 import { ThreadWorker } from "./threads/ThreadWorker";
 
 /**
- * @hidden
+ * @internal
  */
 export const NodeWorkerCompiler = async (
   type: "process" | "thread",
@@ -41,6 +41,9 @@ export const NodeWorkerCompiler = async (
   // }
 });
 
+/**
+ * @internal
+ */
 const uuid = () =>
   "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;

--- a/src/protocols/workers/internal/WebWorkerCompiler.ts
+++ b/src/protocols/workers/internal/WebWorkerCompiler.ts
@@ -1,7 +1,7 @@
 import { IWorkerCompiler } from "./IWorkerCompiler";
 
 /**
- * @hidden
+ * @internal
  */
 export const WebWorkerCompiler = async (): Promise<IWorkerCompiler> => ({
   compile: async (content) => {

--- a/src/protocols/workers/internal/processes/ProcessChannel.ts
+++ b/src/protocols/workers/internal/processes/ProcessChannel.ts
@@ -1,7 +1,7 @@
 import { NodeModule } from "../../../../utils/internal/NodeModule";
 
 /**
- * @hidden
+ * @internal
  */
 export class ProcessChannel {
   public static postMessage(message: any): void {

--- a/src/protocols/workers/internal/processes/ProcessWorker.ts
+++ b/src/protocols/workers/internal/processes/ProcessWorker.ts
@@ -4,7 +4,7 @@ import { NodeModule } from "../../../../utils/internal/NodeModule";
 import { IWorkerCompiler } from "../IWorkerCompiler";
 
 /**
- * @hidden
+ * @internal
  */
 export async function ProcessWorker(): Promise<IWorkerCompiler.Creator> {
   const { fork } = await NodeModule.cp.get();

--- a/src/protocols/workers/internal/threads/ThreadPort.ts
+++ b/src/protocols/workers/internal/threads/ThreadPort.ts
@@ -1,11 +1,7 @@
-//================================================================
-
-/** @module tgrid.protocols.workers */
-//================================================================
 import { NodeModule } from "../../../../utils/internal/NodeModule";
 
 /**
- * @hidden
+ * @internal
  */
 
 export async function ThreadPort() {
@@ -34,6 +30,10 @@ export async function ThreadPort() {
   }
   return ThreadPort;
 }
+
+/**
+ * @internal
+ */
 export namespace ThreadPort {
   export async function isWorkerThread(): Promise<boolean> {
     const { parentPort } = await NodeModule.thread.get();

--- a/src/protocols/workers/internal/threads/ThreadWorker.ts
+++ b/src/protocols/workers/internal/threads/ThreadWorker.ts
@@ -1,14 +1,10 @@
-//================================================================
-
-/** @module tgrid.protocols.workers */
-//================================================================
 import type thread from "worker_threads";
 
 import { NodeModule } from "../../../../utils/internal/NodeModule";
 import { IWorkerCompiler } from "../IWorkerCompiler";
 
 /**
- * @hidden
+ * @internal
  */
 export async function ThreadWorker(): Promise<IWorkerCompiler.Creator> {
   const { Worker } = await NodeModule.thread.get();

--- a/src/utils/internal/NodeModule.ts
+++ b/src/utils/internal/NodeModule.ts
@@ -9,6 +9,9 @@ import { Singleton, is_node } from "tstl";
 import type * as __thread from "worker_threads";
 import type * as __ws from "ws";
 
+/**
+ * @internal
+ */
 export namespace NodeModule {
   export const cp: Singleton<Promise<typeof __cp>> = new Singleton(() =>
     import2("child_process"),
@@ -37,4 +40,7 @@ export namespace NodeModule {
   };
 }
 
+/**
+ * @internal
+ */
 const __global = is_node() ? global : undefined;

--- a/src/utils/internal/serializeError.ts
+++ b/src/utils/internal/serializeError.ts
@@ -1,3 +1,6 @@
+/**
+ * @internal
+ */
 export const serializeError = (error: any) => {
   if (
     typeof error === "object" &&

--- a/test/browser/web-client.ts
+++ b/test/browser/web-client.ts
@@ -1,4 +1,4 @@
-import { Driver, WebConnector } from "tgrid";
+import { Driver, WebSocketConnector } from "tgrid";
 import { InvalidArgument } from "tstl";
 
 import { ICalculator } from "../controllers/ICalculator";
@@ -6,10 +6,8 @@ import { complete } from "./internal";
 
 window.onload = async () => {
   for (let i: number = 0; i < 5; ++i) {
-    const connector: WebConnector<null, null, ICalculator> = new WebConnector(
-      null,
-      null,
-    );
+    const connector: WebSocketConnector<null, null, ICalculator> =
+      new WebSocketConnector(null, null);
     await connector.connect("ws://127.0.0.1:10489");
 
     const driver: Driver<ICalculator> = connector.getDriver();

--- a/test/browser/web-server.ts
+++ b/test/browser/web-server.ts
@@ -1,9 +1,10 @@
-import { WebServer } from "tgrid";
+import { WebSocketServer } from "tgrid";
 
 import { Calculator } from "../providers/Calculator";
 
 async function main(): Promise<void> {
-  const server: WebServer<object, Calculator, null> = new WebServer();
+  const server: WebSocketServer<object, Calculator, null> =
+    new WebSocketServer();
   let index: number = 0;
 
   await server.open(10489, async (acceptor) => {

--- a/test/node/components/test_security.ts
+++ b/test/node/components/test_security.ts
@@ -1,4 +1,4 @@
-import { Driver, WebConnector, WebServer } from "tgrid";
+import { Driver, WebSocketConnector, WebSocketServer } from "tgrid";
 
 import { Calculator, Scientific } from "../../providers/Calculator";
 
@@ -24,13 +24,14 @@ async function must_be_error(
 }
 
 export async function test_security(): Promise<void> {
-  const server: WebServer<object, CustomCalculator, null> = new WebServer();
+  const server: WebSocketServer<object, CustomCalculator, null> =
+    new WebSocketServer();
   await server.open(10101, async (acceptor) => {
     await acceptor.accept(new CustomCalculator());
   });
 
-  const connector: WebConnector<null, null, CustomCalculator> =
-    new WebConnector(null, null);
+  const connector: WebSocketConnector<null, null, CustomCalculator> =
+    new WebSocketConnector(null, null);
   await connector.connect("ws://127.0.0.1:10101");
 
   const calc: Driver<CustomCalculator> = connector.getDriver();

--- a/test/node/protocols/web/test_web_calculator.ts
+++ b/test/node/protocols/web/test_web_calculator.ts
@@ -1,4 +1,4 @@
-import { Driver, WebConnector, WebServer } from "tgrid";
+import { Driver, WebSocketConnector, WebSocketServer } from "tgrid";
 import { Vector } from "tstl";
 
 import { ICalculator } from "../../../controllers/ICalculator";
@@ -11,8 +11,8 @@ export async function test_web_calculator(): Promise<void> {
   //----
   // SERVER
   //----
-  const server: WebServer<object, Calculator | Vector<number>, null> =
-    new WebServer();
+  const server: WebSocketServer<object, Calculator | Vector<number>, null> =
+    new WebSocketServer();
   await server.open(PORT, async (acceptor) => {
     // SPEICFY PROVIDER
     const provider = /calculator/.test(acceptor.path)
@@ -26,8 +26,11 @@ export async function test_web_calculator(): Promise<void> {
   //----
   // CLIENTS
   //----
-  const connector: WebConnector<null, null, ICalculator | IVector<number>> =
-    new WebConnector(null, null);
+  const connector: WebSocketConnector<
+    null,
+    null,
+    ICalculator | IVector<number>
+  > = new WebSocketConnector(null, null);
 
   // const RE-USABILITY
   for (const path of ["calculator", "vector"])

--- a/test/node/protocols/web/test_web_chat.ts
+++ b/test/node/protocols/web/test_web_chat.ts
@@ -1,4 +1,4 @@
-import { Driver, WebConnector, WebServer } from "tgrid";
+import { Driver, WebSocketConnector, WebSocketServer } from "tgrid";
 import { sleep_for } from "tstl";
 
 import { IChatPrinter } from "../../../controllers/IChatPrinter";
@@ -13,7 +13,7 @@ CLIENT
 ---------------------------------------------------------------- */
 class Client {
   private name_!: string;
-  private connector_!: WebConnector<null, IChatPrinter, IChatService>;
+  private connector_!: WebSocketConnector<null, IChatPrinter, IChatService>;
   private scripts_!: IScript[];
 
   private service_!: Driver<IChatService>;
@@ -21,7 +21,7 @@ class Client {
   public async participate(name: string): Promise<void> {
     // ASSIGN MEMBERS
     this.name_ = name;
-    this.connector_ = new WebConnector(null, {
+    this.connector_ = new WebSocketConnector(null, {
       print: (name: string, message: string): void => {
         this.scripts_.push({ name: name, message: message });
       },
@@ -51,11 +51,11 @@ class Client {
   SERVER
 ---------------------------------------------------------------- */
 class Server {
-  private server_!: WebServer<object, IChatService, IChatPrinter>;
+  private server_!: WebSocketServer<object, IChatService, IChatPrinter>;
   private scripts_!: IScript[];
 
   public async open(): Promise<void> {
-    this.server_ = new WebServer();
+    this.server_ = new WebSocketServer();
     this.scripts_ = [];
 
     await this.server_.open(PORT, async (acceptor) => {

--- a/test/node/protocols/web/test_web_header.ts
+++ b/test/node/protocols/web/test_web_header.ts
@@ -1,4 +1,4 @@
-import { WebConnector, WebServer } from "tgrid";
+import { WebSocketConnector, WebSocketServer } from "tgrid";
 
 const PORT = 10101;
 const TOKEN = "asdfawe4fasdfchswrtgadfg";
@@ -8,16 +8,14 @@ interface IHeaders {
 }
 
 export async function test_web_header(): Promise<void> {
-  const server: WebServer<IHeaders, null, null> = new WebServer();
+  const server: WebSocketServer<IHeaders, null, null> = new WebSocketServer();
   await server.open(PORT, async (acceptor) => {
     if (acceptor.header.token !== TOKEN) await acceptor.reject();
     else await acceptor.accept(null);
   });
 
-  const connector: WebConnector<IHeaders, null, null> = new WebConnector(
-    { token: TOKEN },
-    null,
-  );
+  const connector: WebSocketConnector<IHeaders, null, null> =
+    new WebSocketConnector({ token: TOKEN }, null);
   await connector.connect(`ws://127.0.0.1:${PORT}`);
   await connector.close();
 

--- a/test/node/protocols/web/test_web_mutex.ts
+++ b/test/node/protocols/web/test_web_mutex.ts
@@ -1,4 +1,4 @@
-import { Driver, WebConnector, WebServer } from "tgrid";
+import { Driver, WebSocketConnector, WebSocketServer } from "tgrid";
 import {
   DomainError,
   Mutex,
@@ -29,10 +29,8 @@ class Provider {
 }
 
 async function _Test_client(): Promise<void> {
-  const connector: WebConnector<null, null, Provider> = new WebConnector(
-    null,
-    null,
-  );
+  const connector: WebSocketConnector<null, null, Provider> =
+    new WebSocketConnector(null, null);
   await connector.connect(`ws://127.0.0.1:${PORT}`);
 
   const driver: Driver<Provider> = connector.getDriver();
@@ -53,7 +51,7 @@ export async function test_web_mutex(): Promise<void> {
   // PREPARES
   //----
   // OPEN SERVER
-  const server: WebServer<object, Provider, null> = new WebServer();
+  const server: WebSocketServer<object, Provider, null> = new WebSocketServer();
   const mutex: Mutex = new Mutex();
   const vector: Vector<number> = new Vector();
   let index: number = 0;

--- a/test/node/protocols/web/test_web_reject.ts
+++ b/test/node/protocols/web/test_web_reject.ts
@@ -1,9 +1,9 @@
-import { WebConnector, WebServer } from "tgrid";
+import { WebSocketConnector, WebSocketServer } from "tgrid";
 
 const PORT = 10101;
 
 export async function test_web_reject(): Promise<void> {
-  const server: WebServer<null, null, null> = new WebServer();
+  const server: WebSocketServer<null, null, null> = new WebSocketServer();
 
   // TEST RE-USABILITY TOO
   for (let i: number = 0; i < 5; ++i) {
@@ -11,10 +11,8 @@ export async function test_web_reject(): Promise<void> {
       await acceptor.reject(1001, "Rejected by test automation program.");
     });
 
-    const connector: WebConnector<null, null, null> = new WebConnector(
-      null,
-      null,
-    );
+    const connector: WebSocketConnector<null, null, null> =
+      new WebSocketConnector(null, null);
     let error: Error | null = null;
 
     try {

--- a/test/node/protocols/web/test_web_server_close.ts
+++ b/test/node/protocols/web/test_web_server_close.ts
@@ -1,16 +1,14 @@
-import { WebConnector, WebServer } from "tgrid";
+import { WebSocketConnector, WebSocketServer } from "tgrid";
 
 const PORT = 10101;
 
 export async function test_web_server_close(): Promise<void> {
-  const server: WebServer<null, null, null> = new WebServer();
+  const server: WebSocketServer<null, null, null> = new WebSocketServer();
   await server.open(PORT, (acceptor) => acceptor.accept(null));
 
   for (let i: number = 0; i < 100; ++i) {
-    const connector: WebConnector<null, null, null> = new WebConnector(
-      null,
-      null,
-    );
+    const connector: WebSocketConnector<null, null, null> =
+      new WebSocketConnector(null, null);
     await connector.connect(`ws://127.0.0.1:${PORT}`);
   }
   await server.close();


### PR DESCRIPTION
Changed class names of WebSocket related for clarity.

- `WebServer` -> `WebSocketServer`
- `WebAcceptor` -> `WebSocketAcceptor`
- `WebConnector` -> `WebSocketConnector`
- `WebError` -> `WebSocketError`
