### PR TITLE
Fix some typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ I always welcome your suggestion. When you publishing a suggestion, then please 
 
   - A description of the problem you're trying to solve.
   - An overview of the suggested solution.
-  - Examples of how the suggestion whould work in various places.
+  - Examples of how the suggestion would work in various places.
     - Code examples showing the expected behavior.
 
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can quickly experience `TGrid` on the playground websites:
   - [Remote Function Call](https://stackblitz.com/~/github.com/samchon/tgrid.example.remote-function-call?file=src/client.ts&view=editor)
   - [Remote Object Call](https://stackblitz.com/~/github.com/samchon/tgrid.example.remote-object-call?file=src/client.ts&view=editor)
   - [Object Oriented Network](https://stackblitz.com/~/github.com/samchon/tgrid.example.object-oriented-network?file=src/composite.ts&view=editor)
-  - [WebSocket Protocool](https://stackblitz.com/~/github.com/samchon/tgrid.example.websocket?file=src/client.ts&view=editor)
+  - [WebSocket Protocol](https://stackblitz.com/~/github.com/samchon/tgrid.example.websocket?file=src/client.ts&view=editor)
   - [Worker Protocol](https://stackblitz.com/~/github.com/samchon/tgrid.example.worker?file=src/client.ts&view=editor)
   - [NestJS WebSocket](https://stackblitz.com/~/github.com/samchon/tgrid.example.nestjs?file=src/calculate.test.ts&view=editor)
 

--- a/src/components/Communicator.ts
+++ b/src/components/Communicator.ts
@@ -75,9 +75,9 @@ export abstract class Communicator<
   }
 
   /**
-   * Destory the communicator.
+   * Destroy the communicator.
    *
-   * A destory function must be called when the network communication has been closed.
+   * A destroy function must be called when the network communication has been closed.
    * It would destroy all function calls in the remote system (by `Driver<Controller>`),
    * which are not returned yet.
    *
@@ -199,7 +199,7 @@ export abstract class Communicator<
    *   - `Driver`: Remote Function Call
    *
    * @template Controller An interface for provided features (functions & objects) from the remote system (`Provider`).
-   * @template UseParametric Whether to convert type of function parameters to be compatible with their pritimive.
+   * @template UseParametric Whether to convert type of function parameters to be compatible with their primitive.
    * @return A Driver for the RFC.
    */
   public getDriver<
@@ -219,7 +219,7 @@ export abstract class Communicator<
   /**
    * Join connection or timeout.
    *
-   * Wait until the connection to be clsoed until timeout.
+   * Wait until the connection to be closed until timeout.
    *
    * @param ms The maximum milliseconds for joining.
    * @return Whether awaken by disconnection or timeout.

--- a/src/components/Invoke.ts
+++ b/src/components/Invoke.ts
@@ -16,7 +16,7 @@ export namespace Invoke {
     uid: number;
 
     /**
-     * Target function (sometimes calsuled in objects) to call.
+     * Target function (sometimes capsuled in objects) to call.
      */
     listener: string;
 

--- a/src/protocols/internal/AcceptorBase.ts
+++ b/src/protocols/internal/AcceptorBase.ts
@@ -9,7 +9,7 @@ import { Communicator } from "../../components/Communicator";
  * [RFC](https://github.com/samchon/tgrid#13-remote-function-call) (Remote Function Call).
  *
  * Also, when declaring this {@link AcceptorBase} type, you've to define two template arguments,
- * *Header* and *Provider*. The *Header* type repersents an initial data gotten from the remote
+ * *Header* and *Provider*. The *Header* type represents an initial data gotten from the remote
  * client after the connection. I hope you and client not to omit it and utilize it as an
  * activation tool to enhance security.
  *
@@ -113,7 +113,7 @@ export abstract class AcceptorBase<
       return new Error(
         `Error on ${this.constructor.name}.${method}(): the connection has been closed.`,
       );
-    // UNKNOWN ERROR, IT MAY NOT OCCURED
+    // UNKNOWN ERROR, IT MAY NOT OCCURRED
     else
       return new Error(
         `Error on ${this.constructor.name}.${method}(): unknown error, but not connected.`,

--- a/src/protocols/internal/ConnectorBase.ts
+++ b/src/protocols/internal/ConnectorBase.ts
@@ -3,11 +3,11 @@ import { Communicator } from "../../components/Communicator";
 /**
  * Basic Connector.
  *
- * The `ConnectorBase` is an abtract communicator class, who can connect to remote server who
+ * The `ConnectorBase` is an abstract communicator class, who can connect to remote server who
  * interacts with clients using the RFC (Remote Function Call).
  *
  * Also, when declaring this {@link ConnectorBase} type, you've to define two template arguments,
- * *Header* and *Provider*. The *Header* type repersents an initial data gotten from the remote
+ * *Header* and *Provider*. The *Header* type represents an initial data gotten from the remote
  * client after the connection. I hope you and client not to omit it and utilize it as an
  * activation tool to enhance security.
  *
@@ -104,7 +104,7 @@ export abstract class ConnectorBase<
       return new Error(
         `Error on ${this.constructor.name}.${method}(): the connection has been closed.`,
       );
-    // UNKNOWN ERROR, IT MAY NOT OCCURED
+    // UNKNOWN ERROR, IT MAY NOT OCCURRED
     else
       return new Error(
         `Error on ${this.constructor.name}.${method}(): unknown error, but not connected.`,

--- a/src/protocols/web/WebSocketAcceptor.ts
+++ b/src/protocols/web/WebSocketAcceptor.ts
@@ -23,7 +23,7 @@ import { IWebSocketCommunicator } from "./internal/IWebSocketCommunicator";
  * whether to {@link accept} the client's connection or {@link reject not},
  * reading the {@link header} and {@link path} properties. If you've decided to
  * accept the connection, call the {@link accept} method with `Provider` instance.
- * Otherwise, reject it thorugh the {@link reject} method.
+ * Otherwise, reject it through the {@link reject} method.
  *
  * After {@link accept accepting} the connection, don't forget to
  * {@link close closing} the connection after your business has been completed
@@ -34,7 +34,7 @@ import { IWebSocketCommunicator } from "./internal/IWebSocketCommunicator";
  * generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments must
  * be same with the ones defined in the {@link WebSocketServer} class.
  *
- * For reference, the first `Header` type repersents an initial data from the
+ * For reference, the first `Header` type represents an initial data from the
  * remote client after the connection. I recommend utilize it as an activation tool
  * for security enhancement. The second generic argument `Provider` represents a
  * provider from server to client, and the other `Remote` means a provider from the
@@ -247,7 +247,7 @@ export class WebSocketAcceptor<
    * Send a ping message to the remote client repeatedly.
    *
    * The ping message would be sent every internal milliseconds, until the
-   * connection be disconnectedd. The remote client will reply with a pong
+   * connection be disconnected. The remote client will reply with a pong
    * message, so that the connection would be alive until be explicitly
    * disconnected.
    *

--- a/src/protocols/web/WebSocketConnector.ts
+++ b/src/protocols/web/WebSocketConnector.ts
@@ -31,7 +31,7 @@ import { WebSocketPolyfill } from "./internal/WebSocketPolyfill";
  * be same with the ones defined in the target {@link WebSocketServer} and
  * {@link WebSocketAcceptor} classes (`Provider` and `Remote` must be reversed).
  *
- * For reference, the first `Header` type repersents an initial data from the
+ * For reference, the first `Header` type represents an initial data from the
  * remote client after the connection. I recommend utilize it as an activation tool
  * for security enhancement. The second generic argument `Provider` represents a
  * provider from client to server, and the other `Remote` means a provider from the
@@ -97,7 +97,7 @@ export class WebSocketConnector<
     this.state_ = WebSocketConnector.State.CONNECTING;
 
     try {
-      // DO CONNNECT
+      // DO CONNECT
       const factory = is_node()
         ? ((await WebSocketPolyfill()) as any)
         : self.WebSocket;
@@ -204,7 +204,7 @@ export class WebSocketConnector<
           }
         });
 
-      // EVENT LISTENRES
+      // EVENT LISTENERS
       this.socket_!.onmessage = once((evt) => {
         if (expired === false) {
           completed = true;

--- a/src/protocols/web/WebSocketError.ts
+++ b/src/protocols/web/WebSocketError.ts
@@ -11,7 +11,7 @@ export class WebSocketError extends Error {
    * Initializer Constructor.
    *
    * @param status Status code.
-   * @param message Detailed message, the reaason why.
+   * @param message Detailed message, the reason why.
    */
   public constructor(status: number, message: string) {
     super(message);

--- a/src/protocols/web/WebSocketServer.ts
+++ b/src/protocols/web/WebSocketServer.ts
@@ -27,7 +27,7 @@ import { WebSocketAcceptor } from "./WebSocketAcceptor";
  * would be propagated to the {@link WebSocketAcceptor}, so that
  * {@link WebSocketAcceptor} would have the same generic arguments, too.
  *
- * For reference, the first `Header` type repersents an initial data from the
+ * For reference, the first `Header` type represents an initial data from the
  * remote client after the connection. I recommend utilize it as an activation tool
  * for security enhancement. The second generic argument `Provider` represents a
  * provider from server to client, and the other `Remote` means a provider from the
@@ -90,7 +90,7 @@ export class WebSocketServer<
         "Error on WebSocketServer.constructor(): only available in NodeJS.",
       );
 
-    // PREPARE SREVER INSTANCE
+    // PREPARE SERVER INSTANCE
     this.options_ = !!key && !!cert ? { key, cert } : null;
 
     // INITIALIZE STATUS & PROTOCOL
@@ -109,7 +109,7 @@ export class WebSocketServer<
    *
    * When implementing the *handler* function with the {@link WebSocketAcceptor} instance, calls the
    * {@link WebSocketAcceptor.accept} method if you want to accept the new client's connection.
-   * Otherwise you dont't want to accept the client and reject its connection, just calls the
+   * Otherwise you don't want to accept the client and reject its connection, just calls the
    * {@link WebSocketAcceptor.reject} instead.
    *
    * @param port Port number to listen.
@@ -181,9 +181,9 @@ export class WebSocketServer<
    *
    * Close all connections between its remote clients ({@link WebSocketConnector}s).
    *
-   * It destories all RFCs (remote function calls) between this server and remote clients
+   * It destroys all RFCs (remote function calls) between this server and remote clients
    * (through `Driver<Controller>`) that are not returned (completed) yet. The destruction
-   * causes all incompleted RFCs to throw exceptions.
+   * causes all incomplete RFCs to throw exceptions.
    */
   public async close(): Promise<void> {
     // VALIDATION

--- a/src/protocols/web/internal/IWebSocketCommunicator.ts
+++ b/src/protocols/web/internal/IWebSocketCommunicator.ts
@@ -9,12 +9,12 @@ export interface IWebSocketCommunicator {
    *
    * Close connection with the remote websocket system.
    *
-   * It destories all RFCs (remote function calls) between this and remote websocket system
+   * It destroys all RFCs (remote function calls) between this and remote websocket system
    * (through `Driver<Controller>`) that are not returned (completed) yet. The destruction
-   * causes all incompleted RFCs to throw exceptions.
+   * causes all incomplete RFCs to throw exceptions.
    *
    * If parametric *code* and *reason* are specified, it means the disconnection is
-   * abnormal and it would throw special exceptions (`WebSocketError`) to the incompleted RFCs.
+   * abnormal and it would throw special exceptions (`WebSocketError`) to the incomplete RFCs.
    *
    * @param code Closing code.
    * @param reason Reason why.

--- a/src/protocols/workers/SharedWorkerAcceptor.ts
+++ b/src/protocols/workers/SharedWorkerAcceptor.ts
@@ -29,7 +29,7 @@ import { IWorkerSystem } from "./internal/IWorkerSystem";
  * generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments must
  * be same with the ones defined in the {@link SharedWorkerServer} class.
  *
- * For reference, the first `Header` type repersents an initial data from the
+ * For reference, the first `Header` type represents an initial data from the
  * remote client after the connection. I recommend utilize it as an activation tool
  * for security enhancement. The second generic argument `Provider` represents a
  * provider from server to client, and the other `Remote` means a provider from the

--- a/src/protocols/workers/SharedWorkerConnector.ts
+++ b/src/protocols/workers/SharedWorkerConnector.ts
@@ -33,7 +33,7 @@ import { WebWorkerCompiler } from "./internal/WebWorkerCompiler";
  * be same with the ones defined in the target {@link WebSocketServer} and
  * {@link SharedWorkerAcceptor} classes (`Provider` and `Remote` must be reversed).
  *
- * For reference, the first `Header` type repersents an initial data from the
+ * For reference, the first `Header` type represents an initial data from the
  * remote client after the connection. I recommend utilize it as an activation tool
  * for security enhancement. The second generic argument `Provider` represents a
  * provider from client to server, and the other `Remote` means a provider from the
@@ -109,7 +109,7 @@ export class SharedWorkerConnector<
     this.state_ = SharedWorkerConnector.State.CONNECTING;
 
     try {
-      // EXECUET THE WORKER
+      // EXECUTE THE WORKER
       const worker: SharedWorker = new SharedWorker(jsFile);
       this.port_ = worker.port as MessagePort;
 
@@ -125,7 +125,7 @@ export class SharedWorkerConnector<
       // SEND HEADERS
       this.port_.postMessage(JSON.stringify(IHeaderWrapper.wrap(this.header)));
 
-      // WAIT ACCEPTION OR REJECTION
+      // WAIT ACCESSION OR REJECTION
       const last: string | SharedWorkerConnector.State.OPEN =
         await this._Handshake(options.timeout, at);
       if (last === SharedWorkerConnector.State.OPEN) {

--- a/src/protocols/workers/SharedWorkerServer.ts
+++ b/src/protocols/workers/SharedWorkerServer.ts
@@ -12,7 +12,7 @@ import { SharedWorkerAcceptor } from "./SharedWorkerAcceptor";
  *
  * The `SharedWorkerServer` is a class representing a server in `SharedWorker`
  * environment. Clients connecting to the `SharedWorkerServer` would communicate
- * with this server through {@link SharedWorkerAcceptor} instaces using RPC
+ * with this server through {@link SharedWorkerAcceptor} instances using RPC
  * (Remote Procedure Call) concept.
  *
  * To open the server, call the {@link open} method with your callback function
@@ -24,7 +24,7 @@ import { SharedWorkerAcceptor } from "./SharedWorkerAcceptor";
  * would be propagated to the {@link SharedWorkerAcceptor}, so that
  * {@link SharedWorkerAcceptor} would have the same generic arguments, too.
  *
- * For reference, the first `Header` type repersents an initial data from the
+ * For reference, the first `Header` type represents an initial data from the
  * remote client after the connection. I recommend utilize it as an activation tool
  * for security enhancement. The second generic argument `Provider` represents a
  * provider from server to client, and the other `Remote` means a provider from the
@@ -72,7 +72,7 @@ export class SharedWorkerServer<
    *
    * When implementing the *handler* function with the {@link SharedWorkerServer}
    * instance, calls the {@link SharedWorkerAcceptor.accept} method if you want to
-   * accept the new client's connection. Otherwise you dont't want to accept the
+   * accept the new client's connection. Otherwise you don't want to accept the
    * client and reject its connection, just calls the
    * {@link SharedWorkerAcceptor.reject} instead.
    *
@@ -115,9 +115,9 @@ export class SharedWorkerServer<
    *
    * Close all connections between its remote clients ({@link SharedWorkerConnector}s).
    *
-   * It destories all RFCs (remote function calls) between this server and remote clients
+   * It destroys all RFCs (remote function calls) between this server and remote clients
    * (through `Driver<Controller>`) that are not returned (completed) yet. The destruction
-   * causes all incompleted RFCs to throw exceptions.
+   * causes all incomplete RFCs to throw exceptions.
    */
   public async close(): Promise<void> {
     // TEST VALIDATION

--- a/src/protocols/workers/WorkerConnector.ts
+++ b/src/protocols/workers/WorkerConnector.ts
@@ -31,7 +31,7 @@ import { WebWorkerCompiler } from "./internal/WebWorkerCompiler";
  * be same with the ones defined in the target {@link WorkerServer} class
  * (`Provider` and `Remote` must be reversed).
  *
- * For reference, the first `Header` type repersents an initial data from the
+ * For reference, the first `Header` type represents an initial data from the
  * remote client after the connection. I recommend utilize it as an activation tool
  * for security enhancement. The second generic argument `Provider` represents a
  * provider from client to server, and the other `Remote` means a provider from the
@@ -106,7 +106,7 @@ export class WorkerConnector<
     options: Partial<WorkerConnector.IConnectOptions> = {},
   ): Promise<void> {
     //----
-    // PRELIMINIARIES
+    // PRELIMINARIES
     //----
     // TEST CONDITION
     this._Test_connection("compile");

--- a/src/protocols/workers/WorkerServer.ts
+++ b/src/protocols/workers/WorkerServer.ts
@@ -21,7 +21,7 @@ import { ThreadPort } from "./internal/threads/ThreadPort";
  * and communicates with client (its parent) directly.
  *
  * To start communication with the client, call the {@link open} method
- * with `Provider` instance. After your business, don't forget {@link close cosing}
+ * with `Provider` instance. After your business, don't forget {@link close closing}
  * this `Worker` instance. If the termination is performed by the
  * {@link WorkerConnector}, you can wait the closing signal through the
  * {@link join} method.
@@ -31,7 +31,7 @@ import { ThreadPort } from "./internal/threads/ThreadPort";
  * be same with the ones defined in the target {@link WorkerConnector} class
  * (`Provider` and `Remote` must be reversed).
  *
- * For reference, the first `Header` type repersents an initial data from the
+ * For reference, the first `Header` type represents an initial data from the
  * client after the connection. I recommend utilize it as an activation tool
  * for security enhancement. The second generic argument `Provider` represents a
  * provider from server to client, and the other `Remote` means a provider from the
@@ -103,7 +103,7 @@ export class WorkerServer<
    * waste of memory leak. Close this worker by yourself ({@link close}) or let
    * client to close this worker ({@link WorkerConnector.close}).
    *
-   * @param provider An object providing featrues for the client.
+   * @param provider An object providing features for the client.
    */
   public async open(provider: Provider): Promise<void> {
     // TEST CONDITION
@@ -242,7 +242,7 @@ export class WorkerServer<
       return new Error(
         "Error on WorkerServer.inspectReady(): server is on closing.",
       );
-    // MAY NOT BE OCCURED
+    // MAY NOT BE OCCURRED
     else if (this.state_ === WorkerServer.State.CLOSED)
       return new Error(
         "Error on WorkerServer.inspectReady(): the server has been closed.",

--- a/src/protocols/workers/internal/IWorkerSystem.ts
+++ b/src/protocols/workers/internal/IWorkerSystem.ts
@@ -22,9 +22,9 @@ export interface IWorkerSystem {
    *
    * Close connection between the remote worker system.
    *
-   * It destroies all RFCs (remote function calls) between this and the remote system
+   * It destroys all RFCs (remote function calls) between this and the remote system
    * (through `Driver<Controller>`) that are not returned (completed) yet. The destruction
-   * causes all incompleted RFCs to throw exceptions.
+   * causes all incomplete RFCs to throw exceptions.
    */
   close(): Promise<void>;
 }

--- a/src/typings/Driver.ts
+++ b/src/typings/Driver.ts
@@ -14,7 +14,7 @@ import { Promisive } from "./Promisive";
  *   - `Driver`: Remote Function Call
  *
  * @template Controller An interface defining features (functions & objects) provided from the remote system.
- * @template UseParametric Whether to convert type of function parameters to be compatible with their pritimive.
+ * @template UseParametric Whether to convert type of function parameters to be compatible with their primitive.
  * @author Jeongho Nam - https://github.com/samchon
  */
 export type Driver<

--- a/test/browser/index.ts
+++ b/test/browser/index.ts
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
     await _Paginate(browser, "worker.html");
     await _Paginate(browser, "shared-worker.html");
   } catch (exp) {
-    console.log("An error has occured");
+    console.log("An error has occurred");
     console.log(exp);
     process.exit(-1);
   }

--- a/test/node/protocols/web/test_web_calculator.ts
+++ b/test/node/protocols/web/test_web_calculator.ts
@@ -14,7 +14,7 @@ export async function test_web_calculator(): Promise<void> {
   const server: WebSocketServer<object, Calculator | Vector<number>, null> =
     new WebSocketServer();
   await server.open(PORT, async (acceptor) => {
-    // SPEICFY PROVIDER
+    // SPECIFY PROVIDER
     const provider = /calculator/.test(acceptor.path)
       ? new Calculator()
       : new Vector<number>();

--- a/test/providers/Calculator.ts
+++ b/test/providers/Calculator.ts
@@ -38,7 +38,7 @@ export class Scientific implements IScientific {
   }
 
   public sqrt(x: number): number {
-    if (x < 0) throw new Error("Negative value on sqaure.");
+    if (x < 0) throw new Error("Negative value on square.");
     return Math.sqrt(x);
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tgrid.com",
   "version": "0.1.0",
-  "description": "Typia Guide Documents",
+  "description": "TGrid Guide Documents",
   "private": true,
   "scripts": {
     "build": "rimraf .next && rimraf out && typedoc && next build && node build/sitemap",
@@ -11,12 +11,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/samchon/typia"
+    "url": "https://github.com/samchon/tgrid"
   },
   "author": "Jeongho Nam",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/samchon/typia/issues"
+    "url": "https://github.com/samchon/tgrid/issues"
   },
   "dependencies": {
     "@emotion/react": "^11.10.6",

--- a/website/pages/docs/examples/remote-function-call.mdx
+++ b/website/pages/docs/examples/remote-function-call.mdx
@@ -3,7 +3,7 @@ import { Callout, Tabs, Tab } from 'nextra-theme-docs'
 ## Outline
 With `TGrid`, you can call remote system's functions as if they are local functions. 
 
-Such remote procedure calling concept is called as [RPC (Remote Procedure Call)](../remote-procedure-call) in the development world, but it contains not only remote funtion call, but also contains [Remote Object Call](./remote-object-call) and [Object Oriented Network](./object-oriented-network). However, in here chapter, we will focus only on the remote function calls.
+Such remote procedure calling concept is called as [RPC (Remote Procedure Call)](../remote-procedure-call) in the development world, but it contains not only remote function call, but also contains [Remote Object Call](./remote-object-call) and [Object Oriented Network](./object-oriented-network). However, in here chapter, we will focus only on the remote function calls.
 
 Let's learn how to call remote functions with `TGrid`.
 
@@ -142,7 +142,7 @@ Here is the websocket server program providing `Calculator` class to the client.
 
 Above ["Client Program"](#client-program) is calling remote functions to the calculator through the `remote` instance of `Driver<ICalculator>` typed. To make the client program works properly, "Server Program" must provide the actual instance implemented the `ICalculator` type. This "Server Program" is serving it providing the `Calculator` class instance in such reason.
 
-By the way, the provided `Calculator` does not have any asynchronous method, but "Client Program" is calling the remote functions with `await` symbol. It's because remote function calls are actually asynchrounous operations perform by the network communication, and `Driver` is a type changing every function's return type to be asynchronous (`Promise<R>`) in such reason.
+By the way, the provided `Calculator` does not have any asynchronous method, but "Client Program" is calling the remote functions with `await` symbol. It's because remote function calls are actually asynchronous operations perform by the network communication, and `Driver` is a type changing every function's return type to be asynchronous (`Promise<R>`) in such reason.
 
 This is the [RPC (Remote Procedure Call)](../remote-procedure-call) of `TGrid`.
 

--- a/website/pages/docs/examples/remote-object-call.mdx
+++ b/website/pages/docs/examples/remote-object-call.mdx
@@ -115,7 +115,7 @@ Here is an example websocket client program, calling remote calculator of the we
 
 As you can see, the client has constructed a `WebSocketConnector` instance with the `Header` and `listener` objects. The `header` object represents a [`Header`](../features/components/#header) component which be directly delivered to the remote system when connecting. The `listener` object is a [`Provider`](../features/components/#provider) component provided for the remote websocket server. It means that, the "Client Program" configures the `header` value to `precision: 2`, and provides `ICalcEventListener` for the remote "Server Program".
 
-After that, you can find out the "Client Program" is calling the remote calculator's function of "Server Program" through [`Driver<ICompositeCalculator>`](../features/components/#driver) typed instance. In the remote function call statements, there is one thing important. It is [`Driver<ICompositeCalculator>`](../features/components/#driver) type supports nested object's funtion calls. 
+After that, you can find out the "Client Program" is calling the remote calculator's function of "Server Program" through [`Driver<ICompositeCalculator>`](../features/components/#driver) typed instance. In the remote function call statements, there is one thing important. It is [`Driver<ICompositeCalculator>`](../features/components/#driver) type supports nested object's function calls.
 
 This is the "Remote Object Call".
 
@@ -272,7 +272,7 @@ export interface IStatisticsCalculator {
 
 The "Server Program" is [providing]([`Provider`](../features/components/#provider)) `CompositeCalculator` class to the websocket client.
 
-By the way, when composing the `CompositeCalculator` class instance as a [`Provider`](../features/components/#provider), you can find out that it is delivering the [`Header`](../features/components/#header) and [`Driver<ICalcEventListener>`](../features/components/#driver) typed instances to the construction parameter. By getting the [`Header`](../features/components/#header) value from the "Client Program", "Server Program" configures precision level of the calculator. 
+By the way, when composing the `CompositeCalculator` class instance as a [`Provider`](../features/components/#provider), you can find out that it is delivering the [`Header`](../features/components/#header) and [`Driver<ICalcEventListener>`](../features/components/#driver) typed instances to the construction parameter. By getting the [`Header`](../features/components/#header) value from the "Client Program", "Server Program" configures precision level of the calculator.
 
 Also, if you click the second `Providers` tab, you can find out that calculators are reporting their calculator operations to the "Client Program" through the [`Driver<ICalcEventListener>`](../features/components/#driver) object. Therefore, whenever the calculator function be called, "Server Program" calls remote function of the "Client Program" for event reporting.
 
@@ -282,9 +282,9 @@ Such two-way remote functions providing and header for initialization, this is t
 
 
 ## Next Chapter
-Until this chapter, we've learned only about simple structructured network systems. Complexity has only come to the [`Provider`](../features/components/#provider) level, and the network systems were always monotonous. Only single type of server and client were existed.
+Until this chapter, we've learned only about simple structured network systems. Complexity has only come to the [`Provider`](../features/components/#provider) level, and the network systems were always monotonous. Only single type of server and client were existed.
 
-By the way, `TGrid` has said that it is useful for developing complicated network system like grid computing in the [README](https://github.com/samchon/tgrid) and index page of guide documents. At the next chapter, we will learn about the complicated network system. 
+By the way, `TGrid` has said that it is useful for developing complicated network system like grid computing in the [README](https://github.com/samchon/tgrid) and index page of guide documents. At the next chapter, we will learn about the complicated network system.
 
   - [Learn from Examples > Object Oriented Network](./object-oriented-network).
 

--- a/website/pages/docs/features/components.mdx
+++ b/website/pages/docs/features/components.mdx
@@ -3,9 +3,9 @@ import { Callout, Tabs, Tab } from 'nextra-theme-docs'
 ## Outline
 This chapter describes key components of the `TGrid` only in the conceptual level.
 
-If you're not familar with theoretical stories, it's okay to skip to the next chapter [Features > WebSocket Protocol](./websocket).
+If you're not familiar with theoretical stories, it's okay to skip to the next chapter [Features > WebSocket Protocol](./websocket).
 
-Even you want to see the example codes, step to the [Learn from Examples > Remote Funtion Call](../examples/remote-function-call) chapter. 
+Even you want to see the example codes, step to the [Learn from Examples > Remote Function Call](../examples/remote-function-call) chapter.
 
 Otherwise, let's study about the key components of the `TGrid`.
 
@@ -305,7 +305,7 @@ Driver of RPC (Remote Procedure Call).
 
 `Driver` is a proxy instance designed to call functions of the remote system. It has a generic argument `Remote` which means the type of remote system's [Provider](#provider), and you can remotely call the functions of the [Provider](#provider) asynchronously through the `Drive<Remote>` instance.
 
-When you call some function of remote [Provider](#provider) by the `Driver<Listener>` instance, it hooks the function call expression, and delivers the function name and arguments (parameter values) to the remote system through the [Communicator](#communicator). If the remote system suceeded to reply the result of the function call, [Communicator](#communicator) resolves the promise of the function call expression with the result, so that makes `Driver<Remote>` working.
+When you call some function of remote [Provider](#provider) by the `Driver<Listener>` instance, it hooks the function call expression, and delivers the function name and arguments (parameter values) to the remote system through the [Communicator](#communicator). If the remote system succeeded to reply the result of the function call, [Communicator](#communicator) resolves the promise of the function call expression with the result, so that makes `Driver<Remote>` working.
 
 Otherwise exception is thrown in the remote [Provider](#provider) function, [Communicator](#communicator) deliveries the exception instance instead to the remote system, so that actual exception being thrown from the `Driver<Remote>` instance.
 

--- a/website/pages/docs/features/websocket.mdx
+++ b/website/pages/docs/features/websocket.mdx
@@ -201,7 +201,7 @@ To open the websocket server, call the [`WebSocketServer.open()`](/api/classes/W
 
 Also, when declaring `WebSocketServer` type, you have to specify three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments would be propagated to the [`WebSocketAcceptor`](#websocketacceptor), so that [`WebSocketAcceptor`](#websocketacceptor) would have the same generic arguments, too.
 
-For reference, the first `Header` type repersents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the remote client to server.
+For reference, the first `Header` type represents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the remote client to server.
 
   - Above example case:
     - `Header`: `ICalcConfig` type
@@ -520,7 +520,7 @@ After the connection, don't forget to [closing](/api/classes/WebSocketConnector-
 
 Also, when declaring this `WebSocketConnector` type, you've to define three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments must be same with the ones defined in the target [`WebSocketServer`](#websocketserver) and [`WebSocketAcceptor`](#websocketacceptor) classes (`Provider` and `Remote` must be reversed).
 
-For reference, the first `Header` type repersents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from client to server, and the other `Remote` means a provider from the remote server to client.
+For reference, the first `Header` type represents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from client to server, and the other `Remote` means a provider from the remote server to client.
 
   - Above example case:
     - `Header`: `ICalcConfig` type
@@ -570,7 +570,7 @@ To utilize `TGrid` in the `NestJS`, upgrade the NestJS application like above.
 Just call the [`WebSocketAdaptor.upgrade()`](https://nestia.io/api/classes/WebSocketAdaptor.html#upgrade) method, then you can utilize `TGrid` in the `NestJS` server.
 
 <Callout type="info">
-About detailed setup or more detailed informations, please refer below docs:
+About detailed setup or more detailed information, please refer below docs:
 
   - [Nestia > Guide Documents > Setup](https://nestia.io/docs/setup/)
   - [Nestia > Guide Documents > WebSocketRoute](https://nestia.io/docs/core/WebSocketRoute/)
@@ -842,10 +842,10 @@ Note that, don't forget to define `@WebSocketRoute.Acceptor()` decorated paramet
 
 Also, when declaring the [`WebSocketAcceptor`](#websocketacceptor) type, ou have to specify three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments would be propagated to the automatically generated [Software Development Kit](#software-development-kit) for the client, so that the client developers will utilize the same generic types what you've defined (`Provider` and `Remote` must be reversed).
 
-For reference, the first `Header` type repersents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the remote client to server.
+For reference, the first `Header` type represents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the remote client to server.
 
 <Callout type="info">
-You can find more detailed informations about `@WebSocketRoute()`:
+You can find more detailed information about `@WebSocketRoute()`:
 
   - [Nestia > Guide Documents > WebSocketRoute](https://nestia.io/docs/core/WebSocketRoute/)]
 </Callout>
@@ -1099,7 +1099,7 @@ Above file is one of the SDK library corresponding to the [`CalculateController`
 Let's see how client developer utilizes the SDK library in the next section.
 
 <Callout type="info">
-You can find more detailed informations about SDK generator:
+You can find more detailed information about SDK generator:
 
   - [Nestia > Guide Documents > S/W Development Kit](https://nestia.io/docs/sdk/sdk/)
 </Callout>

--- a/website/pages/docs/features/worker.mdx
+++ b/website/pages/docs/features/worker.mdx
@@ -111,7 +111,7 @@ export interface IStatisticsCalculator {
 
 Worker Connector.
 
-The `WorkerConnetor` is a [communicator](./components/#communicator) class, which creates an `Worker` instance, and interacts with it through RPC (Remote Procedure Call). In other words, `WorkerConnector` considers the `Worker` instance as a remote server accepting only one client; [`WorkerServer`](#workerserver).
+The `WorkerConnector` is a [communicator](./components/#communicator) class, which creates an `Worker` instance, and interacts with it through RPC (Remote Procedure Call). In other words, `WorkerConnector` considers the `Worker` instance as a remote server accepting only one client; [`WorkerServer`](#workerserver).
 
 You can create the `Worker` instance and communicate with it by [`WorkerConnector.connect()`](/api/classes/WorkerConnector-1.html#connect) or [`WorkerConnector.compile()`](/api/classes/WorkerConnector-1.html#compile) method. The [`WorkerConnector.connect()`](/api/classes/WorkerConnector-1.html#connect) method just opens an existing JS (or TS) file, and the [`WorkerConnector.compile()`](/api/classes/WorkerConnector-1.html#compile) method writes a temporary JS (TS) file and connects to it. Anyway, the `Worker` instanced program must open the [`WorkerServer`](#workerserver).
 
@@ -119,7 +119,7 @@ By the way, don't forget [closing](/api/classes/WorkerConnector-1.html#close) th
 
 Also, when declaring this `WorkerConnector` type, you've to define three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments must be same with the ones defined in the target [`WorkerServer`](#workerserver) class (`Provider` and `Remote` must be reversed).
 
-For reference, the first `Header` type repersents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from client to server, and the other `Remote` means a provider from the remote server to client.
+For reference, the first `Header` type represents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from client to server, and the other `Remote` means a provider from the remote server to client.
 
   - Above example case:
     - `Header`: `ICalcConfig` type
@@ -307,7 +307,7 @@ To start communication with the client, call the [`WorkerServer.open()`](http://
 
 Also, when declaring this WorkerServer type, you've to define three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments must be same with the ones defined in the target [`WorkerConnector`](#workerconnector) class (`Provider` and `Remote` must be reversed).
 
-For reference, the first `Header` type repersents an initial data from the client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the client to server.
+For reference, the first `Header` type represents an initial data from the client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the client to server.
 
   - Above example case:
     - `Header`: `ICalcConfig` type
@@ -492,13 +492,13 @@ export interface IStatisticsCalculator {
 
 Shared Worker Server.
 
-The `SharedWorkerServer` is a class representing a server in `SharedWorker` environment. Clients connecting to the `SharedWorkerServer` would communicate with this server through [`SharedWorkerAcceptor`](#sharedworkeracceptor) instaces using RPC (Remote Procedure Call) concept.
+The `SharedWorkerServer` is a class representing a server in `SharedWorker` environment. Clients connecting to the `SharedWorkerServer` would communicate with this server through [`SharedWorkerAcceptor`](#sharedworkeracceptor) instances using RPC (Remote Procedure Call) concept.
 
 To open the server, call the [`SharedWorkerServer.open()`](/api/classes/SharedWorkerServer-1.html#open) method with your callback function which would be called whenever a [`SharedWorkerAcceptor`](#sharedworkeracceptor) has been newly created by a new client's connection.
 
 Also, when declaring this `SharedWorkerServer` type, you have to define three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments would be propagated to the [`SharedWorkerAcceptor`](#sharedworkeracceptor), so that [`SharedWorkerAcceptor`](#sharedworkeracceptor) would have the same generic arguments, too.
 
-For reference, the first `Header` type repersents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the remote client to server.
+For reference, the first `Header` type represents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the remote client to server.
 
   - Above example case:
     - `Header`: `ICalcConfig` type
@@ -590,13 +590,13 @@ Shared Worker Acceptor.
 
 The `SharedWorkerAcceptor` is a [communicator](./components/#communicator) class interacting with the [`SharedWorkerConnector`](#sharedworkerconnector) through RFC (Remote Function Call), created by the [`SharedWorkerServer`](#sharedworkerserver) class whenever a client connects to the `SharedWorker` instance.
 
-When a remote client connects to the [`SharedWorkerServer`](#sharedworkerserver), so that a new `SharedworkerAcceptor` instance being created, you can determine whether to accept the client's connection or not, reading the [`SharedWorkerAcceptor.header`](/api/classes/SharedWorkerAcceptor-1.html#header-1) property. If you've decided to accept the connection, call the [`SharedWorkerAcceptor.accept()`](/api/classes/SharedWorkerAcceptor-1.html#accept) method with Provider instance. Otherwise, reject it thorugh the [`SharedWorkerAcceptor.reject()`](/api/classes/SharedWorkerAcceptor-1.html#reject) method.
+When a remote client connects to the [`SharedWorkerServer`](#sharedworkerserver), so that a new `SharedWorkerAcceptor` instance being created, you can determine whether to accept the client's connection or not, reading the [`SharedWorkerAcceptor.header`](/api/classes/SharedWorkerAcceptor-1.html#header-1) property. If you've decided to accept the connection, call the [`SharedWorkerAcceptor.accept()`](/api/classes/SharedWorkerAcceptor-1.html#accept) method with Provider instance. Otherwise, reject it thorugh the [`SharedWorkerAcceptor.reject()`](/api/classes/SharedWorkerAcceptor-1.html#reject) method.
 
 After [accepting](/api/classes/SharedWorkerAcceptor-1.html#accept) the connection, don't forget to [closing](/api/classes/SharedWorkerAcceptor-1.html#close) the connection after your business has been completed to clean up the resources. Otherwise the closing must be performed by the remote client, you can wait the remote client's closing signal by the [`SharedWorkerAcceptor.join()`](/api/classes/SharedWorkerAcceptor-1.html#accept) method.
 
-Also, when declaring this `SharedworkerAcceptor` type, you have to define three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments must be same with the ones defined in the [`SharedWorkerServer`](#sharedworkerserver) class.
+Also, when declaring this `SharedWorkerAcceptor` type, you have to define three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments must be same with the ones defined in the [`SharedWorkerServer`](#sharedworkerserver) class.
 
-For reference, the first `Header` type repersents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the remote client to server.
+For reference, the first `Header` type represents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from server to client, and the other `Remote` means a provider from the remote client to server.
 
 ### `SharedWorkerConnector`
 <Tabs items={["Main Program", "Interfaces"]}>
@@ -695,7 +695,7 @@ After the connection, don't forget to [closing](/api/classes/SharedWorkerConnect
 
 Also, when declaring this `SharedWorkerConnector` type, you've to define three generic arguments; `Header`, `Provider` and `Remote`. Those generic arguments must be same with the ones defined in the target [`SharedWorkerServer`](#sharedworkerserver) and [`SharedWorkerAcceptor`](#sharedworkeracceptor) classes (Provider and `Remote` must be reversed).
 
-For reference, the first `Header` type repersents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from client to server, and the other `Remote` means a provider from the remote server to client.
+For reference, the first `Header` type represents an initial data from the remote client after the connection. I recommend utilize it as an activation tool for security enhancement. The second generic argument `Provider` represents a provider from client to server, and the other `Remote` means a provider from the remote server to client.
 
   - Above example case:
     - `Header`: `ICalcConfig` type

--- a/website/pages/docs/remote-procedure-call.mdx
+++ b/website/pages/docs/remote-procedure-call.mdx
@@ -542,18 +542,18 @@ export interface IStatisticsCalculator {
   </Tab>
 </Tabs>
 
-Looking at the above `ICompositeCalculator` type from the "Interfaces" tab, none of the functions are actually asynchrounous. However, the "Client Program" is attaching `await` symbols. It's because every return types of `ICompositeCalculator` have changed to `Promise<R>` types through the `Driver<T>` type.
+Looking at the above `ICompositeCalculator` type from the "Interfaces" tab, none of the functions are actually asynchronous. However, the "Client Program" is attaching `await` symbols. It's because every return types of `ICompositeCalculator` have changed to `Promise<R>` types through the `Driver<T>` type.
 
 As the `Driver<ICompositeCalculator>` typed instance is not a "Client Program"'s own, but the "Server Program"'s own (`CompositeCalculator`), the function call must be passed through the asynchronous network communication. In such reason, the remote function calling cannot be synchronous, but asynchronous, and `Driver<T>` type is casting them.
 
 <Callout type="warning" emoji="💡">
 **Tip**
 
-Description of `Driver` type in the [Features > Components](./features/components) chatper.
+Description of `Driver` type in the [Features > Components](./features/components) chapter.
 
 `Driver` is a proxy instance designed to call functions of the remote system. It has a generic argument `Remote` which means the type of remote system's [Provider](./features/components/#provider), and you can remotely call the functions of the [Provider](#provider) asynchronously through the `Drive<Remote>` instance.
 
-When you call some function of remote [Provider](./features/components/#provider) by the `Driver<Listener>` instance, it hooks the function call expression, and delivers the function name and arguments (parameter values) to the remote system through the [Communicator](./features/components/#communicator). If the remote system suceeded to reply the result of the function call, [Communicator](./features/components/#communicator) resolves the promise of the function call expression with the result, so that makes `Driver<Remote>` working.
+When you call some function of remote [Provider](./features/components/#provider) by the `Driver<Listener>` instance, it hooks the function call expression, and delivers the function name and arguments (parameter values) to the remote system through the [Communicator](./features/components/#communicator). If the remote system succeeded to reply the result of the function call, [Communicator](./features/components/#communicator) resolves the promise of the function call expression with the result, so that makes `Driver<Remote>` working.
 
 Otherwise exception is thrown in the remote [Provider](./features/components/#provider) function, [Communicator](./features/components/#communicator) deliveries the exception instance instead to the remote system, so that actual exception being thrown from the `Driver<Remote>` instance.
 


### PR DESCRIPTION
Only comments and documentations are fixed. Typos in the code are preserved, like: https://github.com/samchon/tgrid/blob/755cef81fc6fc8c763bb15adb714bcb82d259f94/src/components/Communicator.ts#L141 