### PR TITLE
Remove `export import` statements.

### DIFF
--- a/src/protocols/web/WebSocketAcceptor.ts
+++ b/src/protocols/web/WebSocketAcceptor.ts
@@ -1,6 +1,6 @@
 import type http from "http";
 import { sleep_for } from "tstl";
-import type WebSocket from "ws";
+import WebSocket from "ws";
 
 import { Invoke } from "../../components/Invoke";
 import { AcceptorBase } from "../internal/AcceptorBase";
@@ -303,5 +303,5 @@ export namespace WebSocketAcceptor {
   /**
    * Current state of the {@link WebSocketAcceptor}.
    */
-  export import State = AcceptorBase.State;
+  export type State = AcceptorBase.State;
 }

--- a/src/protocols/web/WebSocketConnector.ts
+++ b/src/protocols/web/WebSocketConnector.ts
@@ -299,7 +299,7 @@ export namespace WebSocketConnector {
   /**
    * Current state of the {@link WebSocketConnector}.
    */
-  export import State = ConnectorBase.State;
+  export type State = ConnectorBase.State;
 
   /**
    * Connection options for the {@link WebSocketConnector.connect}.

--- a/src/protocols/web/WebSocketServer.ts
+++ b/src/protocols/web/WebSocketServer.ts
@@ -264,5 +264,5 @@ export namespace WebSocketServer {
   /**
    * Current state of the {@link WebSocketServer}.
    */
-  export import State = IServer.State;
+  export type State = IServer.State;
 }

--- a/src/protocols/workers/SharedWorkerAcceptor.ts
+++ b/src/protocols/workers/SharedWorkerAcceptor.ts
@@ -201,5 +201,5 @@ export namespace SharedWorkerAcceptor {
   /**
    * Current state of the {@link SharedWorkerAcceptor}.
    */
-  export import State = AcceptorBase.State;
+  export type State = AcceptorBase.State;
 }

--- a/src/protocols/workers/SharedWorkerConnector.ts
+++ b/src/protocols/workers/SharedWorkerConnector.ts
@@ -252,7 +252,7 @@ export namespace SharedWorkerConnector {
   /**
    * Current state of the {@link SharedWorkerConnector}.
    */
-  export import State = ConnectorBase.State;
+  export type State = ConnectorBase.State;
 
   /**
    * Connection options for the {@link SharedWorkerConnector.connect}.

--- a/src/protocols/workers/SharedWorkerServer.ts
+++ b/src/protocols/workers/SharedWorkerServer.ts
@@ -183,7 +183,7 @@ export namespace SharedWorkerServer {
   /**
    * Current state of the {@link SharedWorkerServer}.
    */
-  export import State = IServer.State;
+  export type State = IServer.State;
 }
 
 /**

--- a/src/protocols/workers/WorkerConnector.ts
+++ b/src/protocols/workers/WorkerConnector.ts
@@ -330,7 +330,7 @@ export namespace WorkerConnector {
   /**
    * Current state of the {@link WorkerConnector}.
    */
-  export import State = ConnectorBase.State;
+  export type State = ConnectorBase.State;
 
   /**
    * Connection options for the {@link WorkerConnector.connect}.

--- a/src/protocols/workers/WorkerServer.ts
+++ b/src/protocols/workers/WorkerServer.ts
@@ -269,7 +269,7 @@ export namespace WorkerServer {
   /**
    * Current state of the {@link WorkerServer}.
    */
-  export import State = IServer.State;
+  export type State = IServer.State;
 }
 
 //----


### PR DESCRIPTION
Same reason with samchon/openapi#163

--------------

This pull request refactors type definitions across multiple files to replace `export import` with `export type` for improved clarity and consistency. Additionally, it updates the `WebSocketAcceptor` file to directly import the `WebSocket` class instead of using a type-only import.

### Type definition refactoring:

* Replaced `export import State` with `export type State` in the following namespaces to improve clarity:
  - `WebSocketAcceptor` in `src/protocols/web/WebSocketAcceptor.ts`
  - `WebSocketConnector` in `src/protocols/web/WebSocketConnector.ts`
  - `WebSocketServer` in `src/protocols/web/WebSocketServer.ts`
  - `SharedWorkerAcceptor` in `src/protocols/workers/SharedWorkerAcceptor.ts`
  - `SharedWorkerConnector` in `src/protocols/workers/SharedWorkerConnector.ts`
  - `SharedWorkerServer` in `src/protocols/workers/SharedWorkerServer.ts`
  - `WorkerConnector` in `src/protocols/workers/WorkerConnector.ts`
  - `WorkerServer` in `src/protocols/workers/WorkerServer.ts`

### Import adjustment:

* Updated `src/protocols/web/WebSocketAcceptor.ts` to import the `WebSocket` class directly, replacing the type-only import. This ensures the module is properly loaded at runtime.